### PR TITLE
Fix docman verify missing short-nickname partial matches

### DIFF
--- a/docman-tool/verifyDocmanUsers.js
+++ b/docman-tool/verifyDocmanUsers.js
@@ -336,7 +336,10 @@ function areSimilarNameTokens(a, b) {
   const shorter = left.length <= right.length ? left : right;
   const longer = left.length <= right.length ? right : left;
 
-  if (shorter.length >= 4 && longer.includes(shorter)) {
+  // Short names are very often a nickname that's a literal prefix of the full
+  // name (Sam/Samantha, Ben/Benjamin, Al/Albert), so allow substring
+  // containment down to 2 characters instead of requiring 4+.
+  if (shorter.length >= 2 && longer.includes(shorter)) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- `areSimilarNameTokens` required the shorter of two name tokens to be at least 4 characters before attempting substring containment, so a 3-letter nickname like "Sam" could never register as a partial match for "Samantha" (or any other 3-letter-or-shorter nickname: Tom, Ben, Al, Ed, Jo, Kim...).
- Reported case: verifying "Sam McDonald" for Hythe Medical Centre Surgery came back `exists=false, partialMatches=null` even though "Ms Samantha McDonald" was in the Docman user list.
- Lowered the threshold to 2 characters (still skips single letters, which would be pure noise).

## Test plan
- [x] `node --check verifyDocmanUsers.js`
- [x] Verified the exact reported case: "Sam McDonald" now surfaces "Ms Samantha McDonald" as a partial match, without auto-resolving it as an exact match (still flagged for manual review)
- [x] Verified no new false positives: people sharing only a short first name with a different surname (e.g. "Sam Wilson" vs "Sam McDonald") are correctly not flagged