### PR TITLE
Check Docman recipient groups too during verify

### DIFF
--- a/docman-tool/verifyDocmanUsers.js
+++ b/docman-tool/verifyDocmanUsers.js
@@ -336,7 +336,10 @@ function areSimilarNameTokens(a, b) {
   const shorter = left.length <= right.length ? left : right;
   const longer = left.length <= right.length ? right : left;
 
-  if (shorter.length >= 4 && longer.includes(shorter)) {
+  // Short names are very often a nickname that's a literal prefix of the full
+  // name (Sam/Samantha, Ben/Benjamin, Al/Albert), so allow substring
+  // containment down to 2 characters instead of requiring 4+.
+  if (shorter.length >= 2 && longer.includes(shorter)) {
     return true;
   }
 

--- a/docman-tool/verifyDocmanUsers.js
+++ b/docman-tool/verifyDocmanUsers.js
@@ -17,6 +17,16 @@ async function verifyDocmanUsers({ page, usernames }) {
   const baseUrl = new URL(page.url()).origin;
   console.log("✔ Docman environment detected:", baseUrl);
 
+  let groupNames = [];
+  try {
+    groupNames = await readAllRecipientGroupNames(page, baseUrl);
+    console.log(`✔ Loaded ${groupNames.length} Docman recipient group(s).`);
+  } catch (error) {
+    console.log(
+      `⚠ Could not load Docman recipient groups, continuing with users only: ${error.message}`
+    );
+  }
+
   // Navigate to User List using the detected environment.
   await page.goto(`${baseUrl}/Admin/Users/UserList`, {
     waitUntil: "domcontentloaded",
@@ -41,6 +51,7 @@ async function verifyDocmanUsers({ page, usernames }) {
   for (const username of usernames) {
     const exactCandidates = await runSearch(page, filter, username);
     let exactMatch = findBestResolvedMatch(exactCandidates, username);
+    let matchType = exactMatch ? "user" : null;
     const partialMatches = [];
 
     if (!exactMatch) {
@@ -52,6 +63,7 @@ async function verifyDocmanUsers({ page, usernames }) {
         const resolvedFromPart = findBestResolvedMatch(partCandidates, username);
         if (resolvedFromPart) {
           exactMatch = resolvedFromPart;
+          matchType = "user";
           break;
         }
 
@@ -60,16 +72,95 @@ async function verifyDocmanUsers({ page, usernames }) {
       }
     }
 
+    if (!exactMatch && groupNames.length) {
+      const exactGroupMatch = findBestResolvedMatch(groupNames, username);
+      if (exactGroupMatch) {
+        exactMatch = exactGroupMatch;
+        matchType = "group";
+      } else if (partialMatches.length < 5) {
+        addRelevantPartialMatches(partialMatches, groupNames, username);
+      }
+    }
+
     results.push({
       searchedName: username,
       exists: Boolean(exactMatch),
       docmanUsername: exactMatch || null,
+      matchType,
       partialMatches: partialMatches.length ? partialMatches : null,
       needsManualReview: !exactMatch && partialMatches.length > 0,
     });
   }
 
   return results;
+}
+
+async function readAllRecipientGroupNames(page, baseUrl) {
+  await page.goto(`${baseUrl}/Admin/RecipientGroups/RecipientGroupList`, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
+
+  const authState = await inspectDocmanLoginState(page);
+  if (authState.onLoginPage) {
+    throw new Error(
+      `Docman redirected to login while opening Recipient Groups. Current URL: ${authState.url}`
+    );
+  }
+
+  await page.waitForSelector("table", { timeout: 60000 });
+
+  const names = new Set();
+  const addCurrentPageRows = async () => {
+    for (const name of await readRecipientGroupTableRows(page)) {
+      names.add(name);
+    }
+  };
+
+  await addCurrentPageRows();
+
+  const pageHrefs = await page.evaluate(() =>
+    Array.from(
+      document.querySelectorAll('a.dropdown-item[href*="RecipientGroups/PageMove"]')
+    ).map((a) => a.getAttribute("href"))
+  );
+
+  // The pagination links live inside a collapsed dropdown, so they aren't
+  // "visible" to Playwright's normal click - dispatch a real click on the
+  // anchor directly (a plain page.goto to the same href does not reliably
+  // advance Docman's server-side paging state).
+  for (const href of pageHrefs) {
+    const clicked = await page.evaluate((targetHref) => {
+      const link = document.querySelector(`a.dropdown-item[href="${targetHref}"]`);
+      if (!link) return false;
+      link.click();
+      return true;
+    }, href);
+    if (!clicked) continue;
+
+    await page.waitForLoadState("domcontentloaded", { timeout: 15000 }).catch(() => {});
+    await page.waitForTimeout(300);
+    await addCurrentPageRows();
+  }
+
+  return [...names];
+}
+
+async function readRecipientGroupTableRows(page) {
+  return await page.evaluate(() => {
+    const tables = Array.from(document.querySelectorAll("table"));
+    const groupTable = tables.find((table) =>
+      /description/i.test((table.querySelector("thead") || {}).textContent || "")
+    );
+    if (!groupTable) return [];
+
+    return Array.from(groupTable.querySelectorAll("tbody tr"))
+      .map((row) => {
+        const firstCell = row.querySelector("td");
+        return firstCell ? firstCell.textContent.trim() : "";
+      })
+      .filter(Boolean);
+  });
 }
 
 async function waitForUserListReady(page) {


### PR DESCRIPTION
## Summary
- verifyDocmanUsers only ever checked the Users list, so a name that exists only as a Recipient Group (e.g. "Readcoders") always came back as a full miss (exists=false, partialMatches=null) even when it was sitting right there in Docman.
- Added readAllRecipientGroupNames, which loads every group name from the Recipient Groups page (no search box there, unlike Users) across all pages, and folds group matches into the same exact/partial-match logic already used for users.
- New `matchType` field on each result ("user" or "group") so callers can tell where a match came from.

**Note:** this branch stacks on #17 (the short-nickname partial-match fix) since it touches the same file - merge #17 first, or this diff will include both changes until it does.

## Test plan
- [x] `node --check verifyDocmanUsers.js`
- [x] Verified against the live Morlais Health Centre Docman session (via the already-authenticated CDP browser): "Readcoders" now resolves `exists=true, matchType=group` (17 groups loaded across the 2 real pages); "PTECH" (confirmed not to exist as a user or a group) still correctly comes back as a miss
- [x] Confirmed pagination on the Recipient Groups page requires a real click on the anchor (a plain navigation to the same href does not reliably advance Docman's server-side paging state) - verified round-trip Page1 -> Page2 -> Page1 returns consistent data each time